### PR TITLE
Swap feedback handle button for link to form

### DIFF
--- a/src/components/authentication/LoginButton.jsx
+++ b/src/components/authentication/LoginButton.jsx
@@ -27,9 +27,12 @@ class LoginButton extends React.Component{
   render() {
     let { userId } = this.props;
     return (
-      <li onClick={ this.handleClick.bind(this) } className={ this.classes() }>
-        { userId || 'Feedback' }
-      </li>
+      //<li onClick={ this.handleClick.bind(this) } className={ this.classes() }>
+      //  { userId || 'Feedback' }
+      //</li>
+	  <li className={ this.classes() }>
+	    <a className={ this.classes() } href="https://docs.google.com/forms/d/1oqhvHKn4huwlxXEdlDJ9z1udg53tSUCkNB7i6fe_Ll4/viewform" target="_blank" >Feedback</a>
+	  </li>
     )
   }
 };


### PR DESCRIPTION
(for some reason the original pull request went to the old repo in the Unacademic organization)

This commit changes the feedback button to link to a feedback form. The
styling is not appropriate and still needs fixing.
